### PR TITLE
Fix for issue 20.

### DIFF
--- a/src/verify.cpp
+++ b/src/verify.cpp
@@ -1299,6 +1299,9 @@ bool verify_plan(istream & plan, bool useOrderInformation, bool lenientMode, int
     if (result == 0) {
         if (rl.rlim_cur < kStackSize) {
             rl.rlim_cur = kStackSize;
+            if (rl.rlim_cur > rl.rlim_max ) {
+              rl.rlim_cur = rl.rlim_max;
+            }
             result = setrlimit(RLIMIT_STACK, &rl);
             if (result != 0) {
                 cerr << "Could not set the stack size. setrlimit returned: " << result << endl;


### PR DESCRIPTION
At least on MacOS, it's not possible to set the stack limit beyond the (externally-set) max.  This checks to make sure that we don't try to set the stack limit too high.

Fixes #20