### PR TITLE
Check if plan stream is good.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -283,6 +283,10 @@ int main(int argc, char** argv) {
 	// do not preprocess the instance at all if we are validating a solution
 	if (verifyPlan){
 		ifstream * plan  = new ifstream(inputFiles[doutfile]);
+                if (! plan->good() ) {
+                  cerr << "Unable to open " << inputFiles[doutfile] << endl;
+                  return 1;
+                }
 		bool result = verify_plan(*plan, useOrderInPlanVerification, lenientVerify, verbosity);
 		cout << "Plan verification result: ";
 		if (result) cout << color(COLOR_GREEN,"true",MODE_BOLD);


### PR DESCRIPTION
Previously if the plan file didn't exist, pandaPIparser would hang attempting to validate.

Addresses #26 